### PR TITLE
Ignore updates to elasticsearch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
   open-pull-requests-limit: 10
   allow:
   - dependency-type: production
+  ignore:
+    # Newer client versions incompatible - see https://opensearch.org/docs/clients/index/
+    - dependency-name: elasticsearch
 
 - package-ecosystem: docker
   directory: "/"


### PR DESCRIPTION
https://trello.com/c/s6V6B7Pv/2302-work-out-what-to-do-with-our-elasticsearch-client

Elastic have chosen to make their client incompatible with the hosted Elasticsearch we use (https://github.com/elastic/elasticsearch-py/issues/1666). So we can't take future updates without breaking things.

Snyk will warn us if there are any security issues with the current version.